### PR TITLE
Setup Travis to compile standard repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: java
+jdk:
+- oraclejdk8
+
+# Handle git submodules yourself
+git:
+    submodules: false
+
+# Use sed to replace the SSH URL with the public URL, then initialize submodules
+before_install:
+- sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+- git submodule update --init --recursive
+
+install:
+- git clone https://github.com/chopshop-166/wpilib-mirror.git ~/wpilib
+
+notifications:
+  email: none
+
+script: ant jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ git:
     submodules: false
 
 # Use sed to replace the SSH URL with the public URL, then initialize submodules
-before_install:
-- sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
-- git submodule update --init --recursive
+# Not necessary due to a lack of submodules
+#before_install:
+#- sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+#- git submodule update --init --recursive
 
 install:
 - git clone https://github.com/chopshop-166/wpilib-mirror.git ~/wpilib

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,14 @@ jdk:
 git:
     submodules: false
 
-# Use sed to replace the SSH URL with the public URL, then initialize submodules
-# Not necessary due to a lack of submodules
-#before_install:
-#- sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
-#- git submodule update --init --recursive
-
 install:
 - git clone https://github.com/chopshop-166/wpilib-mirror.git ~/wpilib
+- git clone https://github.com/RoboticsTeam4904/logkitten.git
+- curl -o ~/wpilib/java/current/lib/navx.jar http://www.t4904.xyz/wiki/files/navx/navx.jar
+- curl -o ~/wpilib/java/current/lib/navx_frc.jar http://www.t4904.xyz/wiki/files/navx/navx_frc.jar
+- curl -o ~/wpilib/java/current/ant/build.properties http://www.t4904.xyz/wiki/files/navx/build.properties
 
 notifications:
   email: none
 
-script: ant jar
+script: ant compile

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Standard
+Team 4904 - Standard Library
+
+[![Build Status](https://travis-ci.org/RoboticsTeam4904/standard.svg?branch=master)](https://travis-ci.org/RoboticsTeam4904/standard)
+
+Used as a git submodule in the yearly repository  
+Language: Java

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,21 @@
+<project name="4904Standard" basedir=".">
+  <description>
+  A simple buildfile to satisfy travis
+  </description>
+
+  <!-- version, team number; version is requuired for filepath below -->
+  <property file="${user.home}/wpilib/wpilib.properties"/> 
+  <property file="${user.home}/wpilib/java/${version}/ant/build.properties"/>
+
+  <target name="clean">
+    <delete dir="build"/>
+  </target>
+
+  <target name="compile">
+    <mkdir dir="build/classes"/>
+    <javac srcdir="${basedir}" destdir="build/classes" includeantruntime="false" >
+      <classpath path="${classpath}"/> <!-- classpath var is set in wpilib.properties -->
+    </javac>
+  </target>
+
+</project>


### PR DESCRIPTION
This PR includes:
- an ant `build.xml` file with a `compile` task
- a `travis.yml` file to install dependencies, and call that task
- a README for the repo, which includes a travis badge

**HAS BEEN TESTED ON ROBORIO**

@widakay @c0d3rman 
-aj