### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Standard
+# standard
 Team 4904 - Standard Library
 
 [![Build Status](https://travis-ci.org/RoboticsTeam4904/standard.svg?branch=master)](https://travis-ci.org/RoboticsTeam4904/standard)


### PR DESCRIPTION
This pull request changes the "s" in "standard" to lowercase, in `README.md`.