### PR TITLE
Remove diamond interface to make travis happy

### DIFF
--- a/commands/healthchecks/AbstractHealthCheck.java
+++ b/commands/healthchecks/AbstractHealthCheck.java
@@ -19,7 +19,7 @@ public abstract class AbstractHealthCheck extends TimedCommand { // Many of our 
 	
 	public void runCommandOnState(HealthLevel level, HealthProtectCommand toRun) {
 		if (commands.get(level) == null) {
-			commands.put(level, new ArrayList<>());
+			commands.put(level, new ArrayList<HealthProtectCommand>());
 		}
 		commands.get(level).add(toRun);
 	}


### PR DESCRIPTION
This pull request:
- removes the implicit "diamond interface syntax" typing
- allows misconfigured travis to build

**TESTED ON ROBORIO**