### PR TITLE
add distance sensor framework

### DIFF
--- a/custom/sensors/CANInfraredDistanceSensor.java
+++ b/custom/sensors/CANInfraredDistanceSensor.java
@@ -1,0 +1,27 @@
+package org.usfirst.frc4904.standard.custom.sensors;
+
+
+/**
+ * Infrared Distance Sensor connected via CAN
+ * assumes mode containing distance values is 0
+ */
+public class CANInfraredDistanceSensor extends CANSensor implements DistanceSensor {
+	protected static final int CAN_SENSOR_MODE = 0;
+	
+	/**
+	 * Construct a new Infrared Distance Sensor connected via CAN
+	 * 
+	 * @param name
+	 *        name of the CAN sensor
+	 * @param id
+	 *        ID of CAN sensor (0x600 to 0x700, must correspond to a Teensy or similar)
+	 */
+	public CANInfraredDistanceSensor(String name, int id) {
+		super(name, id);
+	}
+	
+	@Override
+	public double getDistance() {
+		return this.read(CAN_SENSOR_MODE);
+	}
+}

--- a/custom/sensors/CANUltrasonicDistanceSensor.java
+++ b/custom/sensors/CANUltrasonicDistanceSensor.java
@@ -1,0 +1,23 @@
+package org.usfirst.frc4904.standard.custom.sensors;
+
+
+public class CANUltrasonicDistanceSensor extends CANSensor implements DistanceSensor {
+	protected static final int CAN_SENSOR_MODE = 0;
+	
+	/**
+	 * Construct a new Ultrasonic Distance Sensor connected via CAN
+	 * 
+	 * @param name
+	 *        name of the CAN sensor
+	 * @param id
+	 *        ID of CAN sensor (0x600 to 0x700, must correspond to a Teensy or similar)
+	 */
+	public CANUltrasonicDistanceSensor(String name, int id) {
+		super(name, id);
+	}
+	
+	@Override
+	public double getDistance() {
+		return super.read(CAN_SENSOR_MODE);
+	}
+}

--- a/custom/sensors/DistanceSensor.java
+++ b/custom/sensors/DistanceSensor.java
@@ -1,0 +1,11 @@
+package org.usfirst.frc4904.standard.custom.sensors;
+
+
+import org.usfirst.frc4904.standard.custom.Named;
+
+/**
+ * A sensor that provides distance values (of type `double`).
+ */
+public interface DistanceSensor extends Named {
+	double getDistance();
+}


### PR DESCRIPTION
This PR:
- adds `DistanceSensor` interface
- adds `CANInfraredDistanceSensor` class (subclass of CANSensor)