### PR TITLE
Identity Modifier should not multiply each value by 1

### DIFF
--- a/subsystems/motor/speedmodifiers/IdentityModifier.java
+++ b/subsystems/motor/speedmodifiers/IdentityModifier.java
@@ -10,7 +10,7 @@ public class IdentityModifier implements SpeedModifier {
 	/**
 	 * A SpeedModifier that changes nothing.
 	 * It doesn't extend LinearModifier in order to reduce computation time
-	 * and have no same code duplication.
+	 * and have the same code duplication.
 	 */
 	public double modify(double speed) {
 		return speed;

--- a/subsystems/motor/speedmodifiers/IdentityModifier.java
+++ b/subsystems/motor/speedmodifiers/IdentityModifier.java
@@ -5,13 +5,14 @@ package org.usfirst.frc4904.standard.subsystems.motor.speedmodifiers;
  * A SpeedModifier that changes nothing.
  * It extends LinearModifier to reduce code duplication.
  */
-public class IdentityModifier extends LinearModifier {
+public class IdentityModifier implements SpeedModifier {
+	
 	/**
-	 *
 	 * A SpeedModifier that changes nothing.
-	 * It extends LinearModifier to reduce code duplication.
+	 * It doesn't extend LinearModifier in order to reduce computation time
+	 * and have no same code duplication.
 	 */
-	public IdentityModifier() {
-		super(1);
+	public double modify(double speed) {
+		return speed;
 	}
 }


### PR DESCRIPTION
For one thing, super(1) is parsed as an implicit integer cast to double, which is very slow (at least one cpu instruction).
Also, multiplying the speed by 1.0D each time a motor is set is inefficient (hundreds of extra CPU instructions per second)
