### PR TITLE
added minimum nominal output functionality to custom pid controller

### DIFF
--- a/custom/motioncontrollers/CustomPIDController.java
+++ b/custom/motioncontrollers/CustomPIDController.java
@@ -16,7 +16,7 @@ public class CustomPIDController extends MotionController {
 	protected double F;
 	protected double totalError;
 	protected double lastError;
-	protected double minNominalOutput = 0.0;
+	protected double minimumNominalOutput = 0.0;
 	protected boolean justReset;
 	
 	/**
@@ -106,10 +106,10 @@ public class CustomPIDController extends MotionController {
 	/**
 	 * 
 	 * @return
-	 * 		The current minNominalOutput (minimum nominal output) value
+	 * 		The current minimumNominalOutput (minimum nominal output) value
 	 */
-	public double getMinNominalOutput() {
-		return minNominalOutput;
+	public double getMinimumNominalOutput() {
+		return minimumNominalOutput;
 	}
 	
 	/**
@@ -155,12 +155,12 @@ public class CustomPIDController extends MotionController {
 	
 	/**
 	 * 
-	 * @param minNominalOutput
+	 * @param minimumNominalOutput
 	 *        Minimum Nominal Output
 	 *        result will default to this value if less than this
 	 */
-	public void setMinNominalOutput(double minNominalOutput) {
-		this.minNominalOutput = minNominalOutput;
+	public void setMinimumNominalOutput(double minimumNominalOutput) {
+		this.minimumNominalOutput = minimumNominalOutput;
 	}
 	
 	/**
@@ -228,8 +228,8 @@ public class CustomPIDController extends MotionController {
 			// Limit the result to be within the output range [outputMin, outputMax]
 			result = Math.max(Math.min(result, outputMax), outputMin);
 		}
-		if (Math.abs(result) < minNominalOutput) {
-			result = Math.signum(result) * minNominalOutput;
+		if (Math.abs(result) < minimumNominalOutput) {
+			result = Math.signum(result) * minimumNominalOutput;
 		}
 		return result;
 	}

--- a/custom/motioncontrollers/CustomPIDController.java
+++ b/custom/motioncontrollers/CustomPIDController.java
@@ -157,7 +157,11 @@ public class CustomPIDController extends MotionController {
 	 * 
 	 * @param minimumNominalOutput
 	 *        Minimum Nominal Output
-	 *        result will default to this value if less than this
+	 *        result will be set to
+	 *        ±this value if the absolute
+	 *        value of the result is less than
+	 *        this value. This is useful if
+	 *        the motor can only run well above a value.
 	 */
 	public void setMinimumNominalOutput(double minimumNominalOutput) {
 		this.minimumNominalOutput = minimumNominalOutput;

--- a/custom/motioncontrollers/CustomPIDController.java
+++ b/custom/motioncontrollers/CustomPIDController.java
@@ -16,6 +16,7 @@ public class CustomPIDController extends MotionController {
 	protected double F;
 	protected double totalError;
 	protected double lastError;
+	protected double minNominalOutput = 0.0;
 	protected boolean justReset;
 	
 	/**
@@ -103,6 +104,15 @@ public class CustomPIDController extends MotionController {
 	}
 	
 	/**
+	 * 
+	 * @return
+	 * 		The current minNominalOutput (minimum nominal output) value
+	 */
+	public double getMinNominalOutput() {
+		return minNominalOutput;
+	}
+	
+	/**
 	 * Sets the parameters of the PID loop
 	 *
 	 * @param P
@@ -141,6 +151,16 @@ public class CustomPIDController extends MotionController {
 		this.I = I;
 		this.D = D;
 		this.F = F;
+	}
+	
+	/**
+	 * 
+	 * @param minNominalOutput
+	 *        Minimum Nominal Output
+	 *        result will default to this value if less than this
+	 */
+	public void setMinNominalOutput(double minNominalOutput) {
+		this.minNominalOutput = minNominalOutput;
 	}
 	
 	/**
@@ -207,6 +227,9 @@ public class CustomPIDController extends MotionController {
 		if (capOutput) {
 			// Limit the result to be within the output range [outputMin, outputMax]
 			result = Math.max(Math.min(result, outputMax), outputMin);
+		}
+		if (Math.abs(result) < minNominalOutput) {
+			result = Math.signum(result) * minNominalOutput;
 		}
 		return result;
 	}


### PR DESCRIPTION
Added minNominalOutput to CustomPIDController.
added setMinNominalOutput() to CustomPIDController, sets the minNominalOutput.
added getMinNominalOutput() to CustomPIDController, gets the minNominalOutput.
Edited get() so that if |result| is less than the minNominalOutput than it puts it to minNominalOutput or -minNominalOutput depending on if it's above or below 0.