### PR TITLE
Flipped getDistance and getDistanceSafely

### DIFF
--- a/custom/sensors/CANInfraredDistanceSensor.java
+++ b/custom/sensors/CANInfraredDistanceSensor.java
@@ -23,14 +23,7 @@ public class CANInfraredDistanceSensor extends CANSensor implements DistanceSens
 	}
 	
 	@Override
-	public double getDistance() throws InvalidSensorException {
-		int value = read(CANInfraredDistanceSensor.CAN_SENSOR_MODE);
-		LogKitten.d(name + " read value " + value);
-		return value;
-	}
-	
-	@Override
-	public double getDistanceSafely() {
+	public double getDistance() {
 		try {
 			return getDistance();
 		}
@@ -38,5 +31,12 @@ public class CANInfraredDistanceSensor extends CANSensor implements DistanceSens
 			LogKitten.ex(e);
 			return 0;
 		}
+	}
+	
+	@Override
+	public double getDistanceSafely() throws InvalidSensorException {
+		int value = read(CANInfraredDistanceSensor.CAN_SENSOR_MODE);
+		LogKitten.d(name + " read value " + value);
+		return value;
 	}
 }

--- a/custom/sensors/CANUltrasonicDistanceSensor.java
+++ b/custom/sensors/CANUltrasonicDistanceSensor.java
@@ -19,12 +19,7 @@ public class CANUltrasonicDistanceSensor extends CANSensor implements DistanceSe
 	}
 	
 	@Override
-	public double getDistance() throws InvalidSensorException {
-		return super.read(CANUltrasonicDistanceSensor.CAN_SENSOR_MODE);
-	}
-	
-	@Override
-	public double getDistanceSafely() {
+	public double getDistance() {
 		try {
 			return getDistance();
 		}
@@ -32,5 +27,10 @@ public class CANUltrasonicDistanceSensor extends CANSensor implements DistanceSe
 			LogKitten.ex(e);
 			return 0;
 		}
+	}
+	
+	@Override
+	public double getDistanceSafely() throws InvalidSensorException {
+		return super.read(CANUltrasonicDistanceSensor.CAN_SENSOR_MODE);
 	}
 }

--- a/custom/sensors/DistanceSensor.java
+++ b/custom/sensors/DistanceSensor.java
@@ -7,7 +7,7 @@ import org.usfirst.frc4904.standard.custom.Named;
  * A sensor that provides distance values (of type `double`).
  */
 public interface DistanceSensor extends Named {
-	double getDistance() throws InvalidSensorException;
-
-	double getDistanceSafely();
+	double getDistance();
+	
+	double getDistanceSafely() throws InvalidSensorException;
 }


### PR DESCRIPTION
Corrected a bug in standard where DistanceSensor's `getDistance` and `getDistanceSafely` have the opposite meanings to the corresponding methods in PIDSensor