### PR TITLE
replaced every instanceof string with object in logkitten

### DIFF
--- a/LogKitten.java
+++ b/LogKitten.java
@@ -147,7 +147,8 @@ public class LogKitten {
 		HAL.sendError(true, logLevel.getSeverity(), false, errorMessage, details, "", false);
 	}
 	
-	public static synchronized void logMessage(String message, KittenLevel level, boolean override) {
+	public static synchronized void logMessage(Object message, KittenLevel level, boolean override) {
+		message = message.toString(); // Not strictly needed, but good practice
 		if (LogKitten.logLevel.compareTo(level) >= 0) {
 			String content = LogKitten.timestamp() + " " + level.getName() + ": " + LogKitten.getLoggerMethodCallerMethodName() + ": " + message + " \n";
 			try {
@@ -180,7 +181,7 @@ public class LogKitten {
 	 * @param message
 	 * @param override
 	 */
-	public static void wtf(String message, boolean override) {
+	public static void wtf(Object message, boolean override) {
 		LogKitten.logMessage(message, KittenLevel.LEVEL_WTF, override);
 	}
 	
@@ -190,7 +191,7 @@ public class LogKitten {
 	 * @param message
 	 *        the message to log
 	 */
-	public static void wtf(String message) { // Log WTF message
+	public static void wtf(Object message) { // Log WTF message
 		LogKitten.logMessage(message, KittenLevel.LEVEL_WTF, false);
 	}
 	
@@ -200,7 +201,7 @@ public class LogKitten {
 	 * @param message
 	 * @param override
 	 */
-	public static void f(String message, boolean override) {
+	public static void f(Object message, boolean override) {
 		LogKitten.logMessage(message, KittenLevel.LEVEL_FATAL, override);
 	}
 	
@@ -210,7 +211,7 @@ public class LogKitten {
 	 * @param message
 	 *        the message to log
 	 */
-	public static void f(String message) { // Log fatal message
+	public static void f(Object message) { // Log fatal message
 		LogKitten.logMessage(message, KittenLevel.LEVEL_FATAL, false);
 	}
 	
@@ -220,7 +221,7 @@ public class LogKitten {
 	 * @param message
 	 * @param override
 	 */
-	public static void e(String message, boolean override) {
+	public static void e(Object message, boolean override) {
 		LogKitten.logMessage(message, KittenLevel.LEVEL_ERROR, override);
 	}
 	
@@ -230,7 +231,7 @@ public class LogKitten {
 	 * @param message
 	 *        the message to log
 	 */
-	public static void e(String message) { // Log error message
+	public static void e(Object message) { // Log error message
 		LogKitten.logMessage(message, KittenLevel.LEVEL_ERROR, false);
 	}
 	
@@ -240,7 +241,7 @@ public class LogKitten {
 	 * @param message
 	 * @param override
 	 */
-	public static void w(String message, boolean override) {
+	public static void w(Object message, boolean override) {
 		LogKitten.logMessage(message, KittenLevel.LEVEL_WARN, override);
 	}
 	
@@ -250,7 +251,7 @@ public class LogKitten {
 	 * @param message
 	 *        the message to log
 	 */
-	public static void w(String message) { // Log warn message
+	public static void w(Object message) { // Log warn message
 		LogKitten.logMessage(message, KittenLevel.LEVEL_WARN, false);
 	}
 	
@@ -260,7 +261,7 @@ public class LogKitten {
 	 * @param message
 	 * @param override
 	 */
-	public static void v(String message, boolean override) {
+	public static void v(Object message, boolean override) {
 		LogKitten.logMessage(message, KittenLevel.LEVEL_VERBOSE, override);
 	}
 	
@@ -270,7 +271,7 @@ public class LogKitten {
 	 * @param message
 	 *        the message to log
 	 */
-	public static void v(String message) { // Log verbose message
+	public static void v(Object message) { // Log verbose message
 		LogKitten.logMessage(message, KittenLevel.LEVEL_VERBOSE, false);
 	}
 	
@@ -280,7 +281,7 @@ public class LogKitten {
 	 * @param message
 	 * @param override
 	 */
-	public static void i(String message, boolean override) {
+	public static void i(Object message, boolean override) {
 		LogKitten.logMessage(message, KittenLevel.LEVEL_VERBOSE, override);
 	}
 	
@@ -289,7 +290,7 @@ public class LogKitten {
 	 *
 	 * @param message
 	 */
-	public static void i(String message) {
+	public static void i(Object message) {
 		LogKitten.logMessage(message, KittenLevel.LEVEL_VERBOSE, false);
 	}
 	
@@ -299,7 +300,7 @@ public class LogKitten {
 	 * @param message
 	 * @param override
 	 */
-	public static void d(String message, boolean override) {
+	public static void d(Object message, boolean override) {
 		LogKitten.logMessage(message, KittenLevel.LEVEL_DEBUG, override);
 	}
 	
@@ -309,7 +310,7 @@ public class LogKitten {
 	 * @param message
 	 *        the message to log
 	 */
-	public static void d(String message) { // Log debug message
+	public static void d(Object message) { // Log debug message
 		LogKitten.logMessage(message, KittenLevel.LEVEL_DEBUG, false);
 	}
 	

--- a/LogKitten.java
+++ b/LogKitten.java
@@ -231,7 +231,7 @@ public class LogKitten {
 	 *        the message to log
 	 */
 	public static void e(Object message) { // Log error message
-		LogKitten.logMessage(message, KittenLevel.LEVEL_ERROR, false);
+		LogKitten.logMessage(message, KittenLevel.ERROR, false);
 	}
 
 	/**


### PR DESCRIPTION
Yes that would require a new function signature for every primitive. However, thanks to Java autoboxing int -> Integer and such, you can pass an int literal to a function that expects an Object. So, LogKitten.wtf(5) will work already for example. @c0d3rman