### PR TITLE
kittenlevel doesn't need to implement comparator, only comparable

### DIFF
--- a/LogKitten.java
+++ b/LogKitten.java
@@ -6,7 +6,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.text.SimpleDateFormat;
-import java.util.Comparator;
 import java.util.Date;
 import edu.wpi.first.wpilibj.hal.HAL;
 
@@ -364,7 +363,7 @@ public class LogKitten {
 		return LogKitten.TIMESTAMP_FORMAT.format(new Date());
 	}
 	
-	public static enum KittenLevel implements Comparable<KittenLevel>, Comparator<KittenLevel> {
+	public static enum KittenLevel implements Comparable<KittenLevel> {
 		// Defined in decreasing order of severity. Enum.compareTo uses the definition order to compare enum values.
 		LEVEL_WTF("WTF"), LEVEL_FATAL("FATAL"), LEVEL_ERROR("ERROR"), LEVEL_WARN("WARN"), LEVEL_VERBOSE("VERBOSE"), LEVEL_DEBUG("DEBUG");
 		private final String name;
@@ -396,14 +395,6 @@ public class LogKitten {
 		 */
 		public String getName() {
 			return name;
-		}
-		
-		/**
-		 * Compare the severity of two KittenLevels
-		 */
-		@Override
-		public int compare(KittenLevel o1, KittenLevel o2) {
-			return o1.getSeverity() - o2.getSeverity();
 		}
 	}
 }


### PR DESCRIPTION
> No one needs to call LEVEL_DEBUG.compare(LEVEL_LOG,LEBEL_VERBOSE); all that's needed is LEVEL_DEBUG.compareTo(LEVEL_LOG), which is comparable.