### PR TITLE
These are never modified therefore can be final

### DIFF
--- a/LogKitten.java
+++ b/LogKitten.java
@@ -17,9 +17,9 @@ public class LogKitten {
 	public final static KittenLevel LEVEL_WARN = KittenLevel.WARN;
 	public final static KittenLevel LEVEL_VERBOSE = KittenLevel.VERBOSE;
 	public final static KittenLevel LEVEL_DEBUG = KittenLevel.DEBUG;
-	public static KittenLevel DEFAULT_LOG_LEVEL = KittenLevel.VERBOSE;
-	public static KittenLevel DEFAULT_PRINT_LEVEL = KittenLevel.WARN;
-	public static KittenLevel DEFAULT_DS_LEVEL = LogKitten.DEFAULT_PRINT_LEVEL;
+	public final static KittenLevel DEFAULT_LOG_LEVEL = KittenLevel.VERBOSE;
+	public final static KittenLevel DEFAULT_PRINT_LEVEL = KittenLevel.WARN;
+	public final static KittenLevel DEFAULT_DS_LEVEL = LogKitten.DEFAULT_PRINT_LEVEL;
 	private static KittenLevel logLevel = LogKitten.DEFAULT_LOG_LEVEL;
 	private static KittenLevel printLevel = LogKitten.DEFAULT_PRINT_LEVEL;
 	private static KittenLevel dsLevel = LogKitten.DEFAULT_DS_LEVEL;


### PR DESCRIPTION
While `logLevel`, `dsLevel`, and `printLevel` are modified, `DEFAULT_LOG_LEVEL` and co aren't