### PR TITLE
Fix CAN Read Issue

### DIFF
--- a/custom/CustomCAN.java
+++ b/custom/CustomCAN.java
@@ -15,7 +15,7 @@ public class CustomCAN {
 	// Because CANJNI is basically static, we do not extend it.
 	protected final int messageID;
 	protected final String name;
-
+	
 	/**
 	 * Constructor for a CustomCAN device.
 	 * The name is local and for your convenience only.
@@ -29,11 +29,11 @@ public class CustomCAN {
 		this.name = name;
 		messageID = 0x00000FFF & id; // Ensure that the messageID is zeroed (32 bit int should be default, but better to be careful)
 	}
-
+	
 	public String getName() {
 		return name;
 	}
-	
+
 	/**
 	 * Used to write data to the device.
 	 *
@@ -43,12 +43,10 @@ public class CustomCAN {
 	 */
 	public void write(byte[] data) {
 		ByteBuffer canData = ByteBuffer.allocateDirect(8);
-		for (int i = 0; i < 8; i++) {
-			canData.put(i, data[i]);
-		}
+		canData.put(data);
 		CANJNI.FRCNetCommCANSessionMuxSendMessage(messageID, canData, CANJNI.CAN_SEND_PERIOD_NO_REPEAT);
 	}
-	
+
 	/**
 	 * Read data as bytebuffer
 	 *
@@ -71,7 +69,7 @@ public class CustomCAN {
 		}
 		return response;
 	}
-	
+
 	/**
 	 * Reads data
 	 * Also stops repeating the last message.

--- a/custom/CustomCAN.java
+++ b/custom/CustomCAN.java
@@ -15,7 +15,7 @@ public class CustomCAN {
 	// Because CANJNI is basically static, we do not extend it.
 	protected final int messageID;
 	protected final String name;
-	
+
 	/**
 	 * Constructor for a CustomCAN device.
 	 * The name is local and for your convenience only.
@@ -27,16 +27,15 @@ public class CustomCAN {
 	 */
 	public CustomCAN(String name, int id) {
 		this.name = name;
-		messageID = id;
+		messageID = 0x00000FFF & id; // Ensure that the messageID is zeroed (32 bit int should be default, but better to be careful)
 	}
-	
+
 	public String getName() {
 		return name;
 	}
-
+	
 	/**
 	 * Used to write data to the device.
-	 * Will continue writing until read is called.
 	 *
 	 * @param data
 	 *        Data to be written. Should be EXACTLY 8 bytes long ONLY.
@@ -49,7 +48,13 @@ public class CustomCAN {
 		}
 		CANJNI.FRCNetCommCANSessionMuxSendMessage(messageID, canData, CANJNI.CAN_SEND_PERIOD_NO_REPEAT);
 	}
-
+	
+	/**
+	 * Read data as bytebuffer
+	 *
+	 * @return
+	 * 		ByteBuffer containing CAN message, or null
+	 */
 	protected ByteBuffer readBuffer() {
 		IntBuffer idBuffer = ByteBuffer.allocateDirect(4).asIntBuffer();
 		idBuffer.clear();
@@ -66,7 +71,7 @@ public class CustomCAN {
 		}
 		return response;
 	}
-
+	
 	/**
 	 * Reads data
 	 * Also stops repeating the last message.

--- a/custom/CustomCAN.java
+++ b/custom/CustomCAN.java
@@ -28,7 +28,7 @@ public class CustomCAN {
 	 */
 	public CustomCAN(String name, int id) {
 		this.name = name;
-		messageID = 0x00000FFF & id; // Ensure that the messageID is zeroed (32 bit int should be default, but better to be careful)
+		messageID = id; // Ensure that the messageID is zeroed (32 bit int should be default, but better to be careful)
 	}
 
 	public String getName() {
@@ -63,7 +63,7 @@ public class CustomCAN {
 		long start = System.currentTimeMillis();
 		while (System.currentTimeMillis() - start < CustomCAN.CAN_MAX_READ_WAIT) {
 			try {
-				response = CANJNI.FRCNetCommCANSessionMuxReceiveMessage(idBuffer, 0x0fffffff, timestamp);
+				response = CANJNI.FRCNetCommCANSessionMuxReceiveMessage(idBuffer, 0x1fffffff, timestamp);
 				break;
 			}
 			catch (CANMessageNotFoundException e) {}

--- a/custom/CustomCAN.java
+++ b/custom/CustomCAN.java
@@ -15,6 +15,7 @@ public class CustomCAN {
 	// Because CANJNI is basically static, we do not extend it.
 	protected final int messageID;
 	protected final String name;
+	private static final int CAN_MAX_READ_WAIT = 5; // How long to wait for a CAN message before returning null
 	
 	/**
 	 * Constructor for a CustomCAN device.
@@ -60,7 +61,7 @@ public class CustomCAN {
 		ByteBuffer timestamp = ByteBuffer.allocate(4);
 		ByteBuffer response = null;
 		long start = System.currentTimeMillis();
-		while (System.currentTimeMillis() - start < 5) {
+		while (System.currentTimeMillis() - start < CustomCAN.CAN_MAX_READ_WAIT) {
 			try {
 				response = CANJNI.FRCNetCommCANSessionMuxReceiveMessage(idBuffer, 0x0fffffff, timestamp);
 				break;

--- a/custom/CustomCAN.java
+++ b/custom/CustomCAN.java
@@ -15,8 +15,8 @@ public class CustomCAN {
 	// Because CANJNI is basically static, we do not extend it.
 	protected final int messageID;
 	protected final String name;
-	private static final int CAN_MAX_READ_WAIT = 5; // How long to wait for a CAN message before returning null
-	
+	private static final int CAN_MAX_READ_WAIT = 5; // How long to wait for a CAN message before returning null (milliseconds)
+
 	/**
 	 * Constructor for a CustomCAN device.
 	 * The name is local and for your convenience only.
@@ -30,11 +30,11 @@ public class CustomCAN {
 		this.name = name;
 		messageID = 0x00000FFF & id; // Ensure that the messageID is zeroed (32 bit int should be default, but better to be careful)
 	}
-	
+
 	public String getName() {
 		return name;
 	}
-
+	
 	/**
 	 * Used to write data to the device.
 	 *
@@ -47,7 +47,7 @@ public class CustomCAN {
 		canData.put(data);
 		CANJNI.FRCNetCommCANSessionMuxSendMessage(messageID, canData, CANJNI.CAN_SEND_PERIOD_NO_REPEAT);
 	}
-
+	
 	/**
 	 * Read data as bytebuffer
 	 *
@@ -70,7 +70,7 @@ public class CustomCAN {
 		}
 		return response;
 	}
-
+	
 	/**
 	 * Reads data
 	 * Also stops repeating the last message.

--- a/custom/CustomCAN.java
+++ b/custom/CustomCAN.java
@@ -47,8 +47,7 @@ public class CustomCAN {
 		for (int i = 0; i < 8; i++) {
 			canData.put(i, data[i]);
 		}
-		CANJNI.FRCNetCommCANSessionMuxSendMessage(messageID, null, CANJNI.CAN_SEND_PERIOD_STOP_REPEATING);
-		CANJNI.FRCNetCommCANSessionMuxSendMessage(messageID, canData, 1);
+		CANJNI.FRCNetCommCANSessionMuxSendMessage(messageID, canData, CANJNI.CAN_SEND_PERIOD_NO_REPEAT);
 	}
 
 	protected ByteBuffer readBuffer() {
@@ -58,14 +57,13 @@ public class CustomCAN {
 		ByteBuffer timestamp = ByteBuffer.allocate(4);
 		ByteBuffer response = null;
 		long start = System.currentTimeMillis();
-		while (System.currentTimeMillis() - start < 10) {
+		while (System.currentTimeMillis() - start < 5) {
 			try {
-				response = CANJNI.FRCNetCommCANSessionMuxReceiveMessage(idBuffer, 0xffffffff, timestamp);
+				response = CANJNI.FRCNetCommCANSessionMuxReceiveMessage(idBuffer, 0x0fffffff, timestamp);
 				break;
 			}
 			catch (CANMessageNotFoundException e) {}
 		}
-		CANJNI.FRCNetCommCANSessionMuxSendMessage(messageID, null, CANJNI.CAN_SEND_PERIOD_STOP_REPEATING);
 		return response;
 	}
 

--- a/custom/CustomNeoPixels.java
+++ b/custom/CustomNeoPixels.java
@@ -12,7 +12,7 @@ public abstract class CustomNeoPixels extends CustomCAN {
 	protected byte B;
 	protected int mode;
 	protected int value;
-
+	
 	/**
 	 * Constructor
 	 * ID should be between 0x600 and 0x700.
@@ -28,11 +28,11 @@ public abstract class CustomNeoPixels extends CustomCAN {
 		mode = 0;
 		value = 0;
 	}
-
+	
 	protected final void setMode(int mode) { // People should be forced to overwrite this with a more user friendly mode system
 		this.mode = mode;
 	}
-
+	
 	/**
 	 * Sets the color of the pattern.
 	 * Values are 0-255.
@@ -46,7 +46,7 @@ public abstract class CustomNeoPixels extends CustomCAN {
 		this.G = (byte) G;
 		this.B = (byte) B;
 	}
-
+	
 	/**
 	 * Sets the progress of the pattern.
 	 * Values are 0 to 32768.
@@ -56,12 +56,11 @@ public abstract class CustomNeoPixels extends CustomCAN {
 	public void setValue(int value) {
 		this.value = value;
 	}
-
+	
 	/**
 	 * Writes LED pattern to Teensy.
 	 */
 	public void update() {
 		super.write(new byte[] {B, G, R, 0x00, (byte) (value >> 8), (byte) (value & 0xFF), (byte) (mode >> 8), (byte) (mode & 0xFF)});
-		super.read();
 	}
 }

--- a/custom/sensors/CANEncoder.java
+++ b/custom/sensors/CANEncoder.java
@@ -14,38 +14,38 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	private PIDSourceType pidSource;
 	private double distancePerPulse;
 	private boolean reverseDirection;
-
+	
 	public CANEncoder(String name, int id, boolean reverseDirection, double distancePerPulse) {
 		super(name, id);
 		this.reverseDirection = reverseDirection;
 		this.distancePerPulse = distancePerPulse;
 		setPIDSourceType(PIDSourceType.kDisplacement);
 	}
-
+	
 	public CANEncoder(String name, int id, boolean reverseDirection) {
 		this(name, id, reverseDirection, 1.0);
 	}
-
+	
 	public CANEncoder(String name, int id, double distancePerPulse) {
 		this(name, id, false, distancePerPulse);
 	}
-
+	
 	public CANEncoder(int id, boolean reverseDirection, double distancePerPulse) {
 		this("CANEncoder", id, reverseDirection, distancePerPulse);
 	}
-
+	
 	public CANEncoder(int id, boolean reverseDirection) {
 		this("CANEncoder", id, reverseDirection, 1.0);
 	}
-
+	
 	public CANEncoder(int id, double distancePerPulse) {
 		this("CANEncoder", id, false, distancePerPulse);
 	}
-
+	
 	public CANEncoder(int id) {
 		this("CANEncoder", id, false, 1.0);
 	}
-
+	
 	/**
 	 * Sets PID mode
 	 * PIDSourceType is either PIDSourceType.kDisplacement
@@ -55,32 +55,32 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	public void setPIDSourceType(PIDSourceType pidSource) {
 		this.pidSource = pidSource;
 	}
-
+	
 	@Override
 	public PIDSourceType getPIDSourceType() {
 		return pidSource;
 	}
-
+	
 	@Override
 	public double getDistancePerPulse() {
 		return distancePerPulse;
 	}
-
+	
 	@Override
 	public void setDistancePerPulse(double distancePerPulse) {
 		this.distancePerPulse = distancePerPulse;
 	}
-
+	
 	@Override
 	public boolean getReverseDirection() {
 		return reverseDirection;
 	}
-
+	
 	@Override
 	public void setReverseDirection(boolean reverseDirection) {
 		this.reverseDirection = reverseDirection;
 	}
-
+	
 	@Override
 	public double pidGetSafely() throws InvalidSensorException {
 		if (pidSource == PIDSourceType.kDisplacement) {
@@ -88,48 +88,48 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 		}
 		return getRate();
 	}
-
+	
 	/**
 	 * Returns the raw number of ticks
 	 */
 	@Override
 	public int getSafely() throws InvalidSensorException {
-		return super.read()[0];
+		return super.readSensor()[0];
 	}
-
+	
 	/**
 	 * Returns the scaled distance rotated by the encoder.
 	 */
 	@Override
 	public double getDistanceSafely() throws InvalidSensorException {
 		if (reverseDirection) {
-			return distancePerPulse * super.read()[0] * -1.0;
+			return distancePerPulse * super.readSensor()[0] * -1.0;
 		} else {
-			return distancePerPulse * super.read()[0];
+			return distancePerPulse * super.readSensor()[0];
 		}
 	}
-
+	
 	/**
 	 * Returns the most recent direction of movement
 	 * (based on the speed)
 	 */
 	@Override
 	public boolean getDirectionSafely() throws InvalidSensorException {
-		return !reverseDirection == (super.read()[1] >= 0);
+		return !reverseDirection == (super.readSensor()[1] >= 0);
 	}
-
+	
 	/**
 	 * Returns the rate of rotation
 	 */
 	@Override
 	public double getRateSafely() throws InvalidSensorException {
 		if (reverseDirection) {
-			return distancePerPulse * super.read()[1] * -1.0;
+			return distancePerPulse * super.readSensor()[1] * -1.0;
 		} else {
-			return distancePerPulse * super.read()[1];
+			return distancePerPulse * super.readSensor()[1];
 		}
 	}
-
+	
 	/**
 	 * Returns true when stopped
 	 */
@@ -137,7 +137,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	public boolean getStoppedSafely() throws InvalidSensorException {
 		return Util.isZero(getRate());
 	}
-
+	
 	/**
 	 * Resets the distance traveled for the encoder
 	 */
@@ -145,7 +145,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	public void reset() {
 		super.write(new byte[] {0x72, 0x65, 0x73, 0x65, 0x74, 0x65, 0x6e, 0x63}); // resetenc
 	}
-
+	
 	@Override
 	public double pidGet() {
 		try {
@@ -156,7 +156,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return 0;
 		}
 	}
-
+	
 	@Override
 	public int get() {
 		try {
@@ -167,7 +167,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return 0;
 		}
 	}
-
+	
 	@Override
 	public double getDistance() {
 		try {
@@ -178,7 +178,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return 0;
 		}
 	}
-
+	
 	@Override
 	public boolean getDirection() {
 		try {
@@ -189,7 +189,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return false;
 		}
 	}
-
+	
 	@Override
 	public boolean getStopped() {
 		try {
@@ -200,7 +200,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return false;
 		}
 	}
-
+	
 	@Override
 	public double getRate() {
 		try {

--- a/custom/sensors/CANEncoder.java
+++ b/custom/sensors/CANEncoder.java
@@ -16,7 +16,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	private boolean reverseDirection;
 
 	public CANEncoder(String name, int id, boolean reverseDirection, double distancePerPulse) {
-		super(name, id, 2);
+		super(name, id);
 		this.reverseDirection = reverseDirection;
 		this.distancePerPulse = distancePerPulse;
 		setPIDSourceType(PIDSourceType.kDisplacement);
@@ -94,7 +94,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	 */
 	@Override
 	public int getSafely() throws InvalidSensorException {
-		return super.read(0); // TODO: what mode numbers will be position and direction?
+		return super.read()[0];
 	}
 
 	/**
@@ -103,9 +103,9 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	@Override
 	public double getDistanceSafely() throws InvalidSensorException {
 		if (reverseDirection) {
-			return distancePerPulse * super.read(0) * -1.0;
+			return distancePerPulse * super.read()[0] * -1.0;
 		} else {
-			return distancePerPulse * super.read(0);
+			return distancePerPulse * super.read()[0];
 		}
 	}
 
@@ -115,7 +115,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	 */
 	@Override
 	public boolean getDirectionSafely() throws InvalidSensorException {
-		return !reverseDirection == (super.read(1) >= 0);
+		return !reverseDirection == (super.read()[1] >= 0);
 	}
 
 	/**
@@ -124,9 +124,9 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	@Override
 	public double getRateSafely() throws InvalidSensorException {
 		if (reverseDirection) {
-			return distancePerPulse * super.read(1) * -1.0;
+			return distancePerPulse * super.read()[1] * -1.0;
 		} else {
-			return distancePerPulse * super.read(1);
+			return distancePerPulse * super.read()[1];
 		}
 	}
 

--- a/custom/sensors/CANEncoder.java
+++ b/custom/sensors/CANEncoder.java
@@ -18,39 +18,39 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	 * Sequence of bytes used to reset an encoder
 	 * Spells out "resetenc" in ASCII
 	 */
-	private static final byte[] RESET_ENCODER_BYTE_SEQUENCE = new byte[] {0x72, 0x65, 0x73, 0x65, 0x74, 0x65, 0x6e, 0x63};
-	
+	private static final byte[] RESET_ENCODER_BYTE_SEQUENCE = "resetenc".getBytes();
+
 	public CANEncoder(String name, int id, boolean reverseDirection, double distancePerPulse) {
 		super(name, id);
 		this.reverseDirection = reverseDirection;
 		this.distancePerPulse = distancePerPulse;
 		setPIDSourceType(PIDSourceType.kDisplacement);
 	}
-	
+
 	public CANEncoder(String name, int id, boolean reverseDirection) {
 		this(name, id, reverseDirection, 1.0);
 	}
-	
+
 	public CANEncoder(String name, int id, double distancePerPulse) {
 		this(name, id, false, distancePerPulse);
 	}
-	
+
 	public CANEncoder(int id, boolean reverseDirection, double distancePerPulse) {
 		this("CANEncoder", id, reverseDirection, distancePerPulse);
 	}
-	
+
 	public CANEncoder(int id, boolean reverseDirection) {
 		this("CANEncoder", id, reverseDirection, 1.0);
 	}
-	
+
 	public CANEncoder(int id, double distancePerPulse) {
 		this("CANEncoder", id, false, distancePerPulse);
 	}
-	
+
 	public CANEncoder(int id) {
 		this("CANEncoder", id, false, 1.0);
 	}
-	
+
 	/**
 	 * Sets PID mode
 	 * PIDSourceType is either PIDSourceType.kDisplacement
@@ -60,32 +60,32 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	public void setPIDSourceType(PIDSourceType pidSource) {
 		this.pidSource = pidSource;
 	}
-	
+
 	@Override
 	public PIDSourceType getPIDSourceType() {
 		return pidSource;
 	}
-	
+
 	@Override
 	public double getDistancePerPulse() {
 		return distancePerPulse;
 	}
-	
+
 	@Override
 	public void setDistancePerPulse(double distancePerPulse) {
 		this.distancePerPulse = distancePerPulse;
 	}
-	
+
 	@Override
 	public boolean getReverseDirection() {
 		return reverseDirection;
 	}
-	
+
 	@Override
 	public void setReverseDirection(boolean reverseDirection) {
 		this.reverseDirection = reverseDirection;
 	}
-	
+
 	@Override
 	public double pidGetSafely() throws InvalidSensorException {
 		if (pidSource == PIDSourceType.kDisplacement) {
@@ -93,7 +93,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 		}
 		return getRate();
 	}
-	
+
 	/**
 	 * Returns the raw number of ticks
 	 */
@@ -101,7 +101,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	public int getSafely() throws InvalidSensorException {
 		return super.readSensor()[0];
 	}
-	
+
 	/**
 	 * Returns the scaled distance rotated by the encoder.
 	 */
@@ -113,7 +113,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return distancePerPulse * super.readSensor()[0];
 		}
 	}
-	
+
 	/**
 	 * Returns the most recent direction of movement
 	 * (based on the speed)
@@ -122,7 +122,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	public boolean getDirectionSafely() throws InvalidSensorException {
 		return !reverseDirection == (super.readSensor()[1] >= 0);
 	}
-	
+
 	/**
 	 * Returns the rate of rotation
 	 */
@@ -134,7 +134,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return distancePerPulse * super.readSensor()[1];
 		}
 	}
-	
+
 	/**
 	 * Returns true when stopped
 	 */
@@ -142,7 +142,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	public boolean getStoppedSafely() throws InvalidSensorException {
 		return Util.isZero(getRate());
 	}
-	
+
 	/**
 	 * Resets the distance traveled for the encoder
 	 */
@@ -150,7 +150,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	public void reset() {
 		super.write(CANEncoder.RESET_ENCODER_BYTE_SEQUENCE); // resetenc
 	}
-	
+
 	@Override
 	public double pidGet() {
 		try {
@@ -161,7 +161,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return 0;
 		}
 	}
-	
+
 	@Override
 	public int get() {
 		try {
@@ -172,7 +172,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return 0;
 		}
 	}
-	
+
 	@Override
 	public double getDistance() {
 		try {
@@ -183,7 +183,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return 0;
 		}
 	}
-	
+
 	@Override
 	public boolean getDirection() {
 		try {
@@ -194,7 +194,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return false;
 		}
 	}
-	
+
 	@Override
 	public boolean getStopped() {
 		try {
@@ -205,7 +205,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return false;
 		}
 	}
-	
+
 	@Override
 	public double getRate() {
 		try {

--- a/custom/sensors/CANEncoder.java
+++ b/custom/sensors/CANEncoder.java
@@ -14,38 +14,38 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	private PIDSourceType pidSource;
 	private double distancePerPulse;
 	private boolean reverseDirection;
-	
+
 	public CANEncoder(String name, int id, boolean reverseDirection, double distancePerPulse) {
 		super(name, id, 2);
 		this.reverseDirection = reverseDirection;
 		this.distancePerPulse = distancePerPulse;
 		setPIDSourceType(PIDSourceType.kDisplacement);
 	}
-	
+
 	public CANEncoder(String name, int id, boolean reverseDirection) {
 		this(name, id, reverseDirection, 1.0);
 	}
-	
+
 	public CANEncoder(String name, int id, double distancePerPulse) {
 		this(name, id, false, distancePerPulse);
 	}
-	
+
 	public CANEncoder(int id, boolean reverseDirection, double distancePerPulse) {
 		this("CANEncoder", id, reverseDirection, distancePerPulse);
 	}
-	
+
 	public CANEncoder(int id, boolean reverseDirection) {
 		this("CANEncoder", id, reverseDirection, 1.0);
 	}
-	
+
 	public CANEncoder(int id, double distancePerPulse) {
 		this("CANEncoder", id, false, distancePerPulse);
 	}
-	
+
 	public CANEncoder(int id) {
 		this("CANEncoder", id, false, 1.0);
 	}
-	
+
 	/**
 	 * Sets PID mode
 	 * PIDSourceType is either PIDSourceType.kDisplacement
@@ -55,32 +55,32 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	public void setPIDSourceType(PIDSourceType pidSource) {
 		this.pidSource = pidSource;
 	}
-	
+
 	@Override
 	public PIDSourceType getPIDSourceType() {
 		return pidSource;
 	}
-	
+
 	@Override
 	public double getDistancePerPulse() {
 		return distancePerPulse;
 	}
-	
+
 	@Override
 	public void setDistancePerPulse(double distancePerPulse) {
 		this.distancePerPulse = distancePerPulse;
 	}
-	
+
 	@Override
 	public boolean getReverseDirection() {
 		return reverseDirection;
 	}
-	
+
 	@Override
 	public void setReverseDirection(boolean reverseDirection) {
 		this.reverseDirection = reverseDirection;
 	}
-	
+
 	@Override
 	public double pidGetSafely() throws InvalidSensorException {
 		if (pidSource == PIDSourceType.kDisplacement) {
@@ -88,7 +88,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 		}
 		return getRate();
 	}
-	
+
 	/**
 	 * Returns the raw number of ticks
 	 */
@@ -96,7 +96,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	public int getSafely() throws InvalidSensorException {
 		return super.read(0); // TODO: what mode numbers will be position and direction?
 	}
-	
+
 	/**
 	 * Returns the scaled distance rotated by the encoder.
 	 */
@@ -108,7 +108,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return distancePerPulse * super.read(0);
 		}
 	}
-	
+
 	/**
 	 * Returns the most recent direction of movement
 	 * (based on the speed)
@@ -117,7 +117,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	public boolean getDirectionSafely() throws InvalidSensorException {
 		return !reverseDirection == (super.read(1) >= 0);
 	}
-	
+
 	/**
 	 * Returns the rate of rotation
 	 */
@@ -129,7 +129,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return distancePerPulse * super.read(1);
 		}
 	}
-	
+
 	/**
 	 * Returns true when stopped
 	 */
@@ -156,7 +156,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return 0;
 		}
 	}
-	
+
 	@Override
 	public int get() {
 		try {
@@ -167,7 +167,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return 0;
 		}
 	}
-	
+
 	@Override
 	public double getDistance() {
 		try {
@@ -178,7 +178,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return 0;
 		}
 	}
-	
+
 	@Override
 	public boolean getDirection() {
 		try {
@@ -189,7 +189,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return false;
 		}
 	}
-	
+
 	@Override
 	public boolean getStopped() {
 		try {
@@ -200,7 +200,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 			return false;
 		}
 	}
-	
+
 	@Override
 	public double getRate() {
 		try {

--- a/custom/sensors/CANEncoder.java
+++ b/custom/sensors/CANEncoder.java
@@ -14,6 +14,11 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	private PIDSourceType pidSource;
 	private double distancePerPulse;
 	private boolean reverseDirection;
+	/**
+	 * Sequence of bytes used to reset an encoder
+	 * Spells out "resetenc" in ASCII
+	 */
+	private static final byte[] RESET_ENCODER_BYTE_SEQUENCE = new byte[] {0x72, 0x65, 0x73, 0x65, 0x74, 0x65, 0x6e, 0x63};
 	
 	public CANEncoder(String name, int id, boolean reverseDirection, double distancePerPulse) {
 		super(name, id);
@@ -143,7 +148,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	 */
 	@Override
 	public void reset() {
-		super.write(new byte[] {0x72, 0x65, 0x73, 0x65, 0x74, 0x65, 0x6e, 0x63}); // resetenc
+		super.write(CANEncoder.RESET_ENCODER_BYTE_SEQUENCE); // resetenc
 	}
 	
 	@Override

--- a/custom/sensors/CANEncoder.java
+++ b/custom/sensors/CANEncoder.java
@@ -137,16 +137,15 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	public boolean getStoppedSafely() throws InvalidSensorException {
 		return Util.isZero(getRate());
 	}
-	
+
 	/**
 	 * Resets the distance traveled for the encoder
 	 */
 	@Override
 	public void reset() {
 		super.write(new byte[] {0x72, 0x65, 0x73, 0x65, 0x74, 0x65, 0x6e, 0x63}); // resetenc
-		super.read(); // and stop transmitting resets once the teensy replies
 	}
-	
+
 	@Override
 	public double pidGet() {
 		try {

--- a/custom/sensors/CANInfraredDistanceSensor.java
+++ b/custom/sensors/CANInfraredDistanceSensor.java
@@ -8,6 +8,8 @@ import org.usfirst.frc4904.standard.LogKitten;
  * assumes mode containing distance values is 0
  */
 public class CANInfraredDistanceSensor extends CANSensor implements DistanceSensor {
+	public static final int DISTANCE_SENSOR_ARRAY_INDEX = 0;
+
 	/**
 	 * Construct a new Infrared Distance Sensor connected via CAN
 	 *
@@ -33,7 +35,7 @@ public class CANInfraredDistanceSensor extends CANSensor implements DistanceSens
 
 	@Override
 	public double getDistanceSafely() throws InvalidSensorException {
-		int value = readSensor()[0];
+		int value = readSensor()[CANInfraredDistanceSensor.DISTANCE_SENSOR_ARRAY_INDEX];
 		LogKitten.d(name + " read value " + value);
 		return value;
 	}

--- a/custom/sensors/CANInfraredDistanceSensor.java
+++ b/custom/sensors/CANInfraredDistanceSensor.java
@@ -35,7 +35,7 @@ public class CANInfraredDistanceSensor extends CANSensor implements DistanceSens
 
 	@Override
 	public double getDistanceSafely() throws InvalidSensorException {
-		int value = read(CANInfraredDistanceSensor.CAN_SENSOR_MODE);
+		int value = read(CANInfraredDistanceSensor.CAN_SENSOR_MODE)[0];
 		LogKitten.d(name + " read value " + value);
 		return value;
 	}

--- a/custom/sensors/CANInfraredDistanceSensor.java
+++ b/custom/sensors/CANInfraredDistanceSensor.java
@@ -8,8 +8,6 @@ import org.usfirst.frc4904.standard.LogKitten;
  * assumes mode containing distance values is 0
  */
 public class CANInfraredDistanceSensor extends CANSensor implements DistanceSensor {
-	protected static final int CAN_SENSOR_MODE = 0;
-
 	/**
 	 * Construct a new Infrared Distance Sensor connected via CAN
 	 *
@@ -35,7 +33,7 @@ public class CANInfraredDistanceSensor extends CANSensor implements DistanceSens
 
 	@Override
 	public double getDistanceSafely() throws InvalidSensorException {
-		int value = read(CANInfraredDistanceSensor.CAN_SENSOR_MODE)[0];
+		int value = readSensor()[0];
 		LogKitten.d(name + " read value " + value);
 		return value;
 	}

--- a/custom/sensors/CANInfraredDistanceSensor.java
+++ b/custom/sensors/CANInfraredDistanceSensor.java
@@ -9,7 +9,7 @@ import org.usfirst.frc4904.standard.LogKitten;
  */
 public class CANInfraredDistanceSensor extends CANSensor implements DistanceSensor {
 	protected static final int CAN_SENSOR_MODE = 0;
-	
+
 	/**
 	 * Construct a new Infrared Distance Sensor connected via CAN
 	 *
@@ -21,18 +21,18 @@ public class CANInfraredDistanceSensor extends CANSensor implements DistanceSens
 	public CANInfraredDistanceSensor(String name, int id) {
 		super(name, id);
 	}
-	
+
 	@Override
 	public double getDistance() {
 		try {
-			return getDistance();
+			return getDistanceSafely();
 		}
 		catch (Exception e) {
 			LogKitten.ex(e);
 			return 0;
 		}
 	}
-	
+
 	@Override
 	public double getDistanceSafely() throws InvalidSensorException {
 		int value = read(CANInfraredDistanceSensor.CAN_SENSOR_MODE);

--- a/custom/sensors/CANSensor.java
+++ b/custom/sensors/CANSensor.java
@@ -11,7 +11,7 @@ import org.usfirst.frc4904.standard.custom.CustomCAN;
  */
 public class CANSensor extends CustomCAN {
 	private final int[] values;
-	private long age; // data age
+	private long lastRead; // data age
 	private final long MAX_AGE = 100;
 
 	/**
@@ -26,7 +26,7 @@ public class CANSensor extends CustomCAN {
 		values = new int[2];
 		values[0] = 0;
 		values[1] = 0;
-		age = System.currentTimeMillis();
+		lastRead = System.currentTimeMillis();
 	}
 
 	/**
@@ -47,10 +47,10 @@ public class CANSensor extends CustomCAN {
 			long data = Long.reverseBytes(rawData.getLong());
 			values[0] = (int) data & 0xFFFFFFFF;
 			values[1] = (int) (data >> 32) & 0xFFFFFFFF;
-			age = System.currentTimeMillis();
+			lastRead = System.currentTimeMillis();
 			return values;
 		}
-		if (System.currentTimeMillis() - age > MAX_AGE) {
+		if (System.currentTimeMillis() - lastRead > MAX_AGE) {
 			throw new InvalidSensorException("CAN data oudated For CAN sensor " + getName());
 		}
 		LogKitten.v("Cached Sensor Value Used\n");

--- a/custom/sensors/CANSensor.java
+++ b/custom/sensors/CANSensor.java
@@ -40,7 +40,7 @@ public class CANSensor extends CustomCAN {
 	 *         this function will throw an InvalidSensorException
 	 *         to indicate that.
 	 */
-	public int[] read(int mode) throws InvalidSensorException {
+	public int[] readSensor() throws InvalidSensorException {
 		ByteBuffer rawData = super.readBuffer();
 		if (rawData != null && rawData.remaining() > 7) {
 			rawData.rewind();
@@ -51,7 +51,7 @@ public class CANSensor extends CustomCAN {
 			return values;
 		}
 		if (System.currentTimeMillis() - age > MAX_AGE) {
-			throw new InvalidSensorException("CAN data oudated For CAN sensor " + getName() + " in mode " + mode);
+			throw new InvalidSensorException("CAN data oudated For CAN sensor " + getName());
 		}
 		LogKitten.v("Cached Sensor Value Used\n");
 		return values;

--- a/custom/sensors/CANSensor.java
+++ b/custom/sensors/CANSensor.java
@@ -12,7 +12,7 @@ import org.usfirst.frc4904.standard.custom.CustomCAN;
 public class CANSensor extends CustomCAN {
 	private final int[] values;
 	private long lastRead; // data age
-	private final long MAX_AGE = 100;
+	private static final long MAX_AGE = 100;
 
 	/**
 	 *
@@ -50,7 +50,7 @@ public class CANSensor extends CustomCAN {
 			lastRead = System.currentTimeMillis();
 			return values;
 		}
-		if (System.currentTimeMillis() - lastRead > MAX_AGE) {
+		if (System.currentTimeMillis() - lastRead > CANSensor.MAX_AGE) {
 			throw new InvalidSensorException("CAN data oudated For CAN sensor " + getName());
 		}
 		LogKitten.v("Cached Sensor Value Used\n");

--- a/custom/sensors/CANSensor.java
+++ b/custom/sensors/CANSensor.java
@@ -12,7 +12,7 @@ import org.usfirst.frc4904.standard.custom.CustomCAN;
 public class CANSensor extends CustomCAN {
 	private final int[] values;
 	private final long[] ages;
-	private final long MAX_AGE = 1000;
+	private final long MAX_AGE = 100;
 
 	/**
 	 *
@@ -38,29 +38,10 @@ public class CANSensor extends CustomCAN {
 	 * @param name
 	 *        Name of CAN sensor
 	 * @param id
-	 *        ID of CAN sensor (0x600 to 0x700, should correspond to a Teensy or similar)
+	 *        ID of CAN sensor (0x600 to 0x6FF, should correspond to a Teensy or similar)
 	 */
 	public CANSensor(String name, int id) {
 		this(name, id, 1);
-	}
-
-	/**
-	 * Read an int from a CAN sensor with retries
-	 * Retries are now ignored
-	 *
-	 * @param mode
-	 *        Which mode to read the sensor in (interpreted by the Teensy)
-	 * @return
-	 * 		The integer the Teensy returned for that mode
-	 *
-	 * @throws InvalidSensorException
-	 *         If the available data is more than one second old,
-	 *         this function will throw an InvalidSensorException
-	 *         to indicate that.
-	 */
-	@Deprecated
-	public int read(int mode, int retryMax) throws InvalidSensorException {
-		return read(mode);
 	}
 
 	/**
@@ -77,7 +58,6 @@ public class CANSensor extends CustomCAN {
 	 *         to indicate that.
 	 */
 	public int read(int mode) throws InvalidSensorException {
-		write(new byte[] {(byte) ((byte) mode & 0xFF), 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01}); // Write to trigger read
 		ByteBuffer rawData = readBuffer();
 		if (rawData != null && rawData.remaining() > 7) {
 			rawData.rewind();

--- a/custom/sensors/CANSensor.java
+++ b/custom/sensors/CANSensor.java
@@ -13,7 +13,7 @@ public class CANSensor extends CustomCAN {
 	private final int[] values;
 	private long lastRead; // data age
 	private static final long MAX_AGE = 100;
-
+	
 	/**
 	 *
 	 * @param name
@@ -28,7 +28,7 @@ public class CANSensor extends CustomCAN {
 		values[1] = 0;
 		lastRead = System.currentTimeMillis();
 	}
-
+	
 	/**
 	 * Read the pair of ints from a CAN sensor
 	 *
@@ -42,7 +42,7 @@ public class CANSensor extends CustomCAN {
 	 */
 	public int[] readSensor() throws InvalidSensorException {
 		ByteBuffer rawData = super.readBuffer();
-		if (rawData != null && rawData.remaining() > 7) {
+		if (rawData != null && rawData.remaining() > 7) { // 8 is minimum CAN message length
 			rawData.rewind();
 			long data = Long.reverseBytes(rawData.getLong());
 			values[0] = (int) data & 0xFFFFFFFF;

--- a/custom/sensors/CANSensor.java
+++ b/custom/sensors/CANSensor.java
@@ -11,7 +11,7 @@ import org.usfirst.frc4904.standard.custom.CustomCAN;
  */
 public class CANSensor extends CustomCAN {
 	private final int[] values;
-	private final long[] ages;
+	private long age; // data age
 	private final long MAX_AGE = 100;
 
 	/**
@@ -20,60 +20,40 @@ public class CANSensor extends CustomCAN {
 	 *        Name of CAN sensor (not really needed)
 	 * @param id
 	 *        ID of CAN sensor (0x600 to 0x700, must correspond to a Teensy or similar)
-	 * @param modes
-	 *        Number of modes for the CAN sensor
-	 */
-	public CANSensor(String name, int id, int modes) {
-		super(name, id);
-		values = new int[modes];
-		ages = new long[modes];
-		for (int i = 0; i < modes; i++) {
-			values[i] = 0; // Should we make this a more obscure value (e.g. 2^32 - 1)?
-			ages[i] = System.currentTimeMillis();
-		}
-	}
-
-	/**
-	 *
-	 * @param name
-	 *        Name of CAN sensor
-	 * @param id
-	 *        ID of CAN sensor (0x600 to 0x6FF, should correspond to a Teensy or similar)
 	 */
 	public CANSensor(String name, int id) {
-		this(name, id, 1);
+		super(name, id);
+		values = new int[2];
+		values[0] = 0;
+		values[1] = 0;
+		age = System.currentTimeMillis();
 	}
 
 	/**
-	 * Read an int from a CAN sensor
+	 * Read the pair of ints from a CAN sensor
 	 *
-	 * @param mode
-	 *        Which mode to read the sensor in (interpreted by the Teensy)
 	 * @return
-	 * 		The integer the Teensy returned for that mode
+	 * 		The latest pair of integers from the sensor
 	 *
 	 * @throws InvalidSensorException
-	 *         If the available data is more than one second old,
+	 *         If the available data is more than one tenth of a second old,
 	 *         this function will throw an InvalidSensorException
 	 *         to indicate that.
 	 */
-	public int read(int mode) throws InvalidSensorException {
-		ByteBuffer rawData = readBuffer();
+	public int[] read(int mode) throws InvalidSensorException {
+		ByteBuffer rawData = super.readBuffer();
 		if (rawData != null && rawData.remaining() > 7) {
 			rawData.rewind();
 			long data = Long.reverseBytes(rawData.getLong());
-			int value = (int) (data & 0xFFFFFFFF);
-			int msgMode = (int) (data >> 32);
-			if (msgMode == mode) {
-				ages[mode] = System.currentTimeMillis();
-				values[mode] = value;
-				return values[mode];
-			}
+			values[0] = (int) data & 0xFFFFFFFF;
+			values[1] = (int) (data >> 32) & 0xFFFFFFFF;
+			age = System.currentTimeMillis();
+			return values;
 		}
-		if (System.currentTimeMillis() - ages[mode] > MAX_AGE) {
-			throw new InvalidSensorException("CAN data oudated For CAN sensor " + getName() + " with ID " + messageID);
+		if (System.currentTimeMillis() - age > MAX_AGE) {
+			throw new InvalidSensorException("CAN data oudated For CAN sensor " + getName() + " in mode " + mode);
 		}
 		LogKitten.v("Cached Sensor Value Used\n");
-		return values[mode];
+		return values;
 	}
 }

--- a/custom/sensors/CANSensor.java
+++ b/custom/sensors/CANSensor.java
@@ -12,7 +12,7 @@ import org.usfirst.frc4904.standard.custom.CustomCAN;
 public class CANSensor extends CustomCAN {
 	private final int[] values;
 	private long lastRead; // data age
-	private static final long MAX_AGE = 100;
+	private static final long MAX_AGE = 100; // How long to keep the last CAN message before throwing an error (milliseconds)
 	
 	/**
 	 *
@@ -42,7 +42,7 @@ public class CANSensor extends CustomCAN {
 	 */
 	public int[] readSensor() throws InvalidSensorException {
 		ByteBuffer rawData = super.readBuffer();
-		if (rawData != null && rawData.remaining() > 7) { // 8 is minimum CAN message length
+		if (rawData != null && rawData.remaining() >= 8) { // 8 is minimum CAN message length
 			rawData.rewind();
 			long data = Long.reverseBytes(rawData.getLong());
 			values[0] = (int) data & 0xFFFFFFFF;

--- a/custom/sensors/CANUltrasonicDistanceSensor.java
+++ b/custom/sensors/CANUltrasonicDistanceSensor.java
@@ -4,6 +4,8 @@ package org.usfirst.frc4904.standard.custom.sensors;
 import org.usfirst.frc4904.standard.LogKitten;
 
 public class CANUltrasonicDistanceSensor extends CANSensor implements DistanceSensor {
+	public static final int DISTANCE_SENSOR_ARRAY_INDEX = 0;
+
 	/**
 	 * Construct a new Ultrasonic Distance Sensor connected via CAN
 	 *
@@ -29,6 +31,6 @@ public class CANUltrasonicDistanceSensor extends CANSensor implements DistanceSe
 
 	@Override
 	public double getDistanceSafely() throws InvalidSensorException {
-		return super.readSensor()[0];
+		return super.readSensor()[CANInfraredDistanceSensor.DISTANCE_SENSOR_ARRAY_INDEX];
 	}
 }

--- a/custom/sensors/CANUltrasonicDistanceSensor.java
+++ b/custom/sensors/CANUltrasonicDistanceSensor.java
@@ -4,8 +4,6 @@ package org.usfirst.frc4904.standard.custom.sensors;
 import org.usfirst.frc4904.standard.LogKitten;
 
 public class CANUltrasonicDistanceSensor extends CANSensor implements DistanceSensor {
-	protected static final int CAN_SENSOR_MODE = 0;
-	
 	/**
 	 * Construct a new Ultrasonic Distance Sensor connected via CAN
 	 *
@@ -17,7 +15,7 @@ public class CANUltrasonicDistanceSensor extends CANSensor implements DistanceSe
 	public CANUltrasonicDistanceSensor(String name, int id) {
 		super(name, id);
 	}
-	
+
 	@Override
 	public double getDistance() {
 		try {
@@ -28,9 +26,9 @@ public class CANUltrasonicDistanceSensor extends CANSensor implements DistanceSe
 			return 0;
 		}
 	}
-	
+
 	@Override
 	public double getDistanceSafely() throws InvalidSensorException {
-		return super.read(CANUltrasonicDistanceSensor.CAN_SENSOR_MODE)[0];
+		return super.readSensor()[0];
 	}
 }

--- a/custom/sensors/CANUltrasonicDistanceSensor.java
+++ b/custom/sensors/CANUltrasonicDistanceSensor.java
@@ -5,7 +5,7 @@ import org.usfirst.frc4904.standard.LogKitten;
 
 public class CANUltrasonicDistanceSensor extends CANSensor implements DistanceSensor {
 	protected static final int CAN_SENSOR_MODE = 0;
-
+	
 	/**
 	 * Construct a new Ultrasonic Distance Sensor connected via CAN
 	 *
@@ -17,7 +17,7 @@ public class CANUltrasonicDistanceSensor extends CANSensor implements DistanceSe
 	public CANUltrasonicDistanceSensor(String name, int id) {
 		super(name, id);
 	}
-
+	
 	@Override
 	public double getDistance() {
 		try {
@@ -28,9 +28,9 @@ public class CANUltrasonicDistanceSensor extends CANSensor implements DistanceSe
 			return 0;
 		}
 	}
-
+	
 	@Override
 	public double getDistanceSafely() throws InvalidSensorException {
-		return super.read(CANUltrasonicDistanceSensor.CAN_SENSOR_MODE);
+		return super.read(CANUltrasonicDistanceSensor.CAN_SENSOR_MODE)[0];
 	}
 }

--- a/custom/sensors/CANUltrasonicDistanceSensor.java
+++ b/custom/sensors/CANUltrasonicDistanceSensor.java
@@ -5,7 +5,7 @@ import org.usfirst.frc4904.standard.LogKitten;
 
 public class CANUltrasonicDistanceSensor extends CANSensor implements DistanceSensor {
 	protected static final int CAN_SENSOR_MODE = 0;
-	
+
 	/**
 	 * Construct a new Ultrasonic Distance Sensor connected via CAN
 	 *
@@ -17,18 +17,18 @@ public class CANUltrasonicDistanceSensor extends CANSensor implements DistanceSe
 	public CANUltrasonicDistanceSensor(String name, int id) {
 		super(name, id);
 	}
-	
+
 	@Override
 	public double getDistance() {
 		try {
-			return getDistance();
+			return getDistanceSafely();
 		}
 		catch (Exception e) {
 			LogKitten.ex(e);
 			return 0;
 		}
 	}
-	
+
 	@Override
 	public double getDistanceSafely() throws InvalidSensorException {
 		return super.read(CANUltrasonicDistanceSensor.CAN_SENSOR_MODE);


### PR DESCRIPTION
This is to fix an ongoing issue with CAN reading and implement a better sensor management system upon that being fixed.
According to typical CAN system designs, sensors should be pushing data constantly. Previously, we were using a call and response system.
There was previously an error where, due to incorrectly initialized CAN ids on the Teensy side, most messages were being lost. In addition, the mask on the RoboRIO side had an error that was leading to further message loss, although this was introduced more recently.

The RoboRIO masking issues are fixed here, and the previous measures taken to allow some communication were eliminated. Sensors no longer attempt to write before reading either.