### PR TITLE
enum implements

### DIFF
--- a/commands/healthchecks/HealthLevel.java
+++ b/commands/healthchecks/HealthLevel.java
@@ -1,6 +1,6 @@
 package org.usfirst.frc4904.standard.commands.healthchecks;
 
 
-public enum HealthLevel implements Comparable<HealthLevel> {
+public enum HealthLevel {
 	PERFECT, SAFE, UNKNOWN, UNSAFE, DANGEROUS;
 }


### PR DESCRIPTION
All enums implement `Comparable` anyway, so it's unnecessary to be explicit about it.