### PR TITLE
more generics

### DIFF
--- a/custom/CommandSendableChooser.java
+++ b/custom/CommandSendableChooser.java
@@ -10,7 +10,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
  * choice on the smart dashboard.
  *
  */
-public class CommandSendableChooser extends SendableChooser {
+public class CommandSendableChooser extends SendableChooser<Command> {
 	/**
 	 * Adds the command object to the smart dashboard.
 	 *
@@ -28,14 +28,5 @@ public class CommandSendableChooser extends SendableChooser {
 	 */
 	public void addDefault(Command object) {
 		super.addDefault(object.getName() + " (default)", object);
-	}
-	
-	/**
-	 * Returns the command selected on the smart
-	 * dashboard.
-	 */
-	@Override
-	public Command getSelected() {
-		return (Command) super.getSelected();
-	}
+	}o
 }

--- a/custom/CommandSendableChooser.java
+++ b/custom/CommandSendableChooser.java
@@ -28,5 +28,5 @@ public class CommandSendableChooser extends SendableChooser<Command> {
 	 */
 	public void addDefault(Command object) {
 		super.addDefault(object.getName() + " (default)", object);
-	}o
+	}
 }


### PR DESCRIPTION
Instead of extending `SendableChooser` it should extend `SendableChooser<Command>`. This fixes all eclipse warnings.