### PR TITLE
thread sleep in loop

### DIFF
--- a/custom/CustomCAN.java
+++ b/custom/CustomCAN.java
@@ -33,7 +33,7 @@ public class CustomCAN {
 	public String getName() {
 		return name;
 	}
-
+	
 	/**
 	 * Used to write data to the device.
 	 * Will continue writing until read is called.
@@ -50,7 +50,7 @@ public class CustomCAN {
 		CANJNI.FRCNetCommCANSessionMuxSendMessage(messageID, null, CANJNI.CAN_SEND_PERIOD_STOP_REPEATING);
 		CANJNI.FRCNetCommCANSessionMuxSendMessage(messageID, canData, 1);
 	}
-
+	
 	protected ByteBuffer readBuffer() {
 		IntBuffer idBuffer = ByteBuffer.allocateDirect(4).asIntBuffer();
 		idBuffer.clear();
@@ -64,11 +64,17 @@ public class CustomCAN {
 				break;
 			}
 			catch (CANMessageNotFoundException e) {}
+			try {
+				Thread.sleep(1);
+			}
+			catch (InterruptedException e) {
+				break;
+			}
 		}
 		CANJNI.FRCNetCommCANSessionMuxSendMessage(messageID, null, CANJNI.CAN_SEND_PERIOD_STOP_REPEATING);
 		return response;
 	}
-
+	
 	/**
 	 * Reads data
 	 * Also stops repeating the last message.


### PR DESCRIPTION
@carterturn @carturn 
what are your thoughts on this? 
a simple test on my laptop

```
long start = System.currentTimeMillis();
	int possibles=0;
	while (System.currentTimeMillis() - start < 10) {
		possibles++;
	}
	System.out.println("in 10ms able to increment an int "+possibles+" times");
```

indicates that a 10ms waiting while loop can run up to 100,000 times. This is because a loop like this uses 100% of a CPU core just running over and over. This pull reduces the polling rate for CAN from ~10,000,000 times a second to 1,000 times a second, by waiting 1ms between each loop iteration. 