### PR TITLE
Added convenience Until/While commands

### DIFF
--- a/commands/RunUntil.java
+++ b/commands/RunUntil.java
@@ -1,0 +1,35 @@
+package org.usfirst.frc4904.standard.commands;
+
+
+import java.util.function.Supplier;
+import edu.wpi.first.wpilibj.command.Command;
+
+public class RunUntil extends Command {
+	protected final Command command;
+	protected final Supplier<Boolean> stopCondition;
+
+	public RunUntil(Command command, Supplier<Boolean> stopCondition) {
+		this.command = command;
+		this.stopCondition = stopCondition;
+	}
+
+	@Override
+	protected void initialize() {
+		command.start();
+	}
+
+	@Override
+	protected boolean isFinished() {
+		return stopCondition.get();
+	}
+
+	@Override
+	protected void end() {
+		command.cancel();
+	}
+
+	@Override
+	protected void interrupted() {
+		end();
+	}
+}

--- a/commands/RunWhile.java
+++ b/commands/RunWhile.java
@@ -1,0 +1,35 @@
+package org.usfirst.frc4904.standard.commands;
+
+
+import java.util.function.Supplier;
+import edu.wpi.first.wpilibj.command.Command;
+
+public class RunWhile extends Command {
+	protected final Command command;
+	protected final Supplier<Boolean> stopCondition;
+
+	public RunWhile(Command command, Supplier<Boolean> stopCondition) {
+		this.command = command;
+		this.stopCondition = stopCondition;
+	}
+
+	@Override
+	protected void initialize() {
+		command.start();
+	}
+
+	@Override
+	protected boolean isFinished() {
+		return !stopCondition.get();
+	}
+
+	@Override
+	protected void end() {
+		command.cancel();
+	}
+
+	@Override
+	protected void interrupted() {
+		end();
+	}
+}

--- a/commands/WaitUntil.java
+++ b/commands/WaitUntil.java
@@ -1,0 +1,18 @@
+package org.usfirst.frc4904.standard.commands;
+
+
+import java.util.function.Supplier;
+import edu.wpi.first.wpilibj.command.Command;
+
+public class WaitUntil extends Command {
+	protected final Supplier<Boolean> stopCondition;
+
+	public WaitUntil(Supplier<Boolean> stopCondition) {
+		this.stopCondition = stopCondition;
+	}
+
+	@Override
+	protected boolean isFinished() {
+		return stopCondition.get();
+	}
+}

--- a/commands/WaitWhile.java
+++ b/commands/WaitWhile.java
@@ -1,0 +1,18 @@
+package org.usfirst.frc4904.standard.commands;
+
+
+import java.util.function.Supplier;
+import edu.wpi.first.wpilibj.command.Command;
+
+public class WaitWhile extends Command {
+	protected final Supplier<Boolean> stopCondition;
+
+	public WaitWhile(Supplier<Boolean> stopCondition) {
+		this.stopCondition = stopCondition;
+	}
+
+	@Override
+	protected boolean isFinished() {
+		return !stopCondition.get();
+	}
+}


### PR DESCRIPTION
Added convenience commands using Boolean Suppliers to run something/wait while/until something is true. Could be used in `2017-Code`'s `Shoot`.