### PR TITLE
Use Runnable in SingleOp

### DIFF
--- a/commands/SingleOp.java
+++ b/commands/SingleOp.java
@@ -3,25 +3,20 @@ package org.usfirst.frc4904.standard.commands;
 
 import edu.wpi.first.wpilibj.command.Command;
 
-public abstract class SingleOp extends Command {
-	abstract protected void runOp();
+public class SingleOp extends Command {
+	protected Runnable op;
 
-	@Override
-	protected void initialize() {
-		runOp();
+	public SingleOp(Runnable op) {
+		this.op = op;
 	}
 
 	@Override
-	protected void execute() {}
+	protected void initialize() {
+		op.run();
+	}
 
 	@Override
 	protected boolean isFinished() {
 		return true;
 	}
-
-	@Override
-	protected void end() {}
-
-	@Override
-	protected void interrupted() {}
 }


### PR DESCRIPTION
`SingleOp` used to be an abstract class, and to use it, one would make an anonymous subclass of it. That was nasty and the syntax of an anonymous class forced line breaks into a lot of places and made them ugly (like `bindCommands()` in 2017-Code's `NathanGain`). Let's use lambdas (implemented through `Runnable`).