### PR TITLE
set a default value for chassis motor speeds

### DIFF
--- a/subsystems/chassis/Chassis.java
+++ b/subsystems/chassis/Chassis.java
@@ -23,6 +23,7 @@ public abstract class Chassis extends Subsystem {
 	public Chassis(String name, Motor... motors) {
 		super(name);
 		this.motors = motors;
+		motorSpeeds = new double[motors.length];
 	}
 
 	@Override


### PR DESCRIPTION
Make sure that the double[] motorSpeeds is initialized in the constructor so it can be retrieved without error before the first chassis command is run.