### PR TITLE
Added exception handling to CustomCAN

### DIFF
--- a/custom/CustomCAN.java
+++ b/custom/CustomCAN.java
@@ -1,8 +1,6 @@
 package org.usfirst.frc4904.standard.custom;
 
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import org.usfirst.frc4904.standard.LogKitten;
@@ -48,9 +46,7 @@ public class CustomCAN {
 			writeSafely(data);
 		}
 		catch (Exception e) {
-			StringWriter sw = new StringWriter();
-			e.printStackTrace(new PrintWriter(sw));
-			LogKitten.e(sw.toString());
+			LogKitten.ex(e);
 		}
 	}
 

--- a/custom/CustomCAN.java
+++ b/custom/CustomCAN.java
@@ -1,8 +1,11 @@
 package org.usfirst.frc4904.standard.custom;
 
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import org.usfirst.frc4904.standard.LogKitten;
 import edu.wpi.first.wpilibj.can.CANJNI;
 import edu.wpi.first.wpilibj.can.CANMessageNotFoundException;
 
@@ -39,9 +42,26 @@ public class CustomCAN {
 	 *
 	 * @param data
 	 *        Data to be written. Should be EXACTLY 8 bytes long ONLY.
-	 * @throws IllegalArgumentException
 	 */
 	public void write(byte[] data) {
+		try {
+			writeSafely(data);
+		}
+		catch (Exception e) {
+			StringWriter sw = new StringWriter();
+			e.printStackTrace(new PrintWriter(sw));
+			LogKitten.e(sw.toString());
+		}
+	}
+
+	/**
+	 * Used to write data to the device.
+	 *
+	 * @param data
+	 *        Data to be written. Should be EXACTLY 8 bytes long ONLY.
+	 * @throws IllegalArgumentException
+	 */
+	public void writeSafely(byte[] data) {
 		ByteBuffer canData = ByteBuffer.allocateDirect(8);
 		canData.put(data);
 		CANJNI.FRCNetCommCANSessionMuxSendMessage(messageID, canData, CANJNI.CAN_SEND_PERIOD_NO_REPEAT);

--- a/custom/CustomCAN.java
+++ b/custom/CustomCAN.java
@@ -6,6 +6,7 @@ import java.nio.IntBuffer;
 import org.usfirst.frc4904.standard.LogKitten;
 import edu.wpi.first.wpilibj.can.CANJNI;
 import edu.wpi.first.wpilibj.can.CANMessageNotFoundException;
+import edu.wpi.first.wpilibj.util.UncleanStatusException;
 
 /**
  * This class allows sending and receiving
@@ -16,7 +17,7 @@ public class CustomCAN {
 	// Because CANJNI is basically static, we do not extend it.
 	protected final int messageID;
 	protected final String name;
-
+	
 	/**
 	 * Constructor for a CustomCAN device.
 	 * The name is local and for your convenience only.
@@ -30,11 +31,11 @@ public class CustomCAN {
 		this.name = name;
 		messageID = id; // Ensure that the messageID is zeroed (32 bit int should be default, but better to be careful)
 	}
-
+	
 	public String getName() {
 		return name;
 	}
-
+	
 	/**
 	 * Used to write data to the device.
 	 *
@@ -45,24 +46,24 @@ public class CustomCAN {
 		try {
 			writeSafely(data);
 		}
-		catch (Exception e) {
+		catch (UncleanStatusException e) {
 			LogKitten.ex(e);
 		}
 	}
-
+	
 	/**
 	 * Used to write data to the device.
 	 *
 	 * @param data
 	 *        Data to be written. Should be EXACTLY 8 bytes long ONLY.
-	 * @throws IllegalArgumentException
+	 * @throws UncleanStatusException
 	 */
 	public void writeSafely(byte[] data) {
 		ByteBuffer canData = ByteBuffer.allocateDirect(8);
 		canData.put(data);
 		CANJNI.FRCNetCommCANSessionMuxSendMessage(messageID, canData, CANJNI.CAN_SEND_PERIOD_NO_REPEAT);
 	}
-
+	
 	/**
 	 * Read data as bytebuffer
 	 *
@@ -81,7 +82,7 @@ public class CustomCAN {
 		catch (CANMessageNotFoundException e) {}
 		return response;
 	}
-
+	
 	/**
 	 * Reads data
 	 * Also stops repeating the last message.


### PR DESCRIPTION
Added exception handling so that the CAN bus being cut doesn't kill the bot.
The stacktrace printing logic should eventually be moved to LogKitten.