### PR TITLE
Made reset on encoders resistant to RoboRIO send error

### DIFF
--- a/custom/sensors/CANEncoder.java
+++ b/custom/sensors/CANEncoder.java
@@ -156,7 +156,9 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	 */
 	@Override
 	public void reset() {
-		super.write(CANEncoder.RESET_ENCODER_BYTE_SEQUENCE); // resetenc
+		for (int i = 0; i < 30; i++) {
+			super.write(CANEncoder.RESET_ENCODER_BYTE_SEQUENCE); // resetenc
+		}
 	}
 
 	@Override

--- a/custom/sensors/CANEncoder.java
+++ b/custom/sensors/CANEncoder.java
@@ -19,6 +19,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	 * Spells out "resetenc" in ASCII
 	 */
 	private static final byte[] RESET_ENCODER_BYTE_SEQUENCE = "resetenc".getBytes();
+	protected static final int RESET_NUMBER_TRIES = 30;
 
 	public CANEncoder(String name, int id, boolean reverseDirection, double distancePerPulse) {
 		super(name, id);
@@ -156,7 +157,7 @@ public class CANEncoder extends CANSensor implements CustomEncoder {
 	 */
 	@Override
 	public void reset() {
-		for (int i = 0; i < 30; i++) {
+		for (int i = 0; i < CANEncoder.RESET_NUMBER_TRIES; i++) {
 			super.write(CANEncoder.RESET_ENCODER_BYTE_SEQUENCE); // resetenc
 		}
 	}


### PR DESCRIPTION
It appears that when the entire robot is active, RoboRIO CAN send is unreliable. This deals with that by sending encoder resets many times. If anyone has time to develop a better solution, that would be good.