### PR TITLE
Fixed PDP printing errors when none actually exist

### DIFF
--- a/custom/sensors/PDP.java
+++ b/custom/sensors/PDP.java
@@ -33,7 +33,7 @@ public class PDP {
 	protected double cachedPower;
 	protected long lastRead;
 	private static final long MAX_AGE = 100; // How long to keep the last CAN message before throwing an error (milliseconds)
-	
+
 	/**
 	 * PDP constructor
 	 *
@@ -52,7 +52,7 @@ public class PDP {
 		cachedEnergy = 0;
 		cachedPower = 0;
 	}
-	
+
 	/**
 	 * PDP constructor
 	 *
@@ -61,7 +61,7 @@ public class PDP {
 	public PDP() {
 		this(0);
 	}
-	
+
 	private void readStatus(int status) throws InvalidSensorException {
 		byte[] rawArray = null;
 		int numberCurrents = 6;
@@ -104,25 +104,26 @@ public class PDP {
 			throw new InvalidSensorException("Can not read voltage from PDP");
 		}
 	}
-	
+
 	private void readEnergy() throws InvalidSensorException {
 		byte[] rawArray;
 		try {
 			rawArray = statusEnergy.read();
 		}
 		catch (CANMessageUnavailableException e) {
-			throw new InvalidSensorException(e);
+			return;
 		}
 		if (rawArray != null) {
 			cachedCurrent = (((rawArray[1] & 0xFF) << 4) | ((rawArray[2] & 0xF0) >> 4)) * 0.125;
 			cachedPower = (((rawArray[1] & 0x0F) << 12) | (rawArray[2] << 4) | ((rawArray[4] & 0xF0) >> 4)) * 0.125;
-			cachedEnergy = (((rawArray[4] & 0x0F) << 24) | (rawArray[5] << 16) | (rawArray[6] << 8) | (rawArray[7])) * 0.000125 * rawArray[0];
+			cachedEnergy = (((rawArray[4] & 0x0F) << 24) | (rawArray[5] << 16) | (rawArray[6] << 8) | (rawArray[7])) * 0.000125
+				* rawArray[0];
 			lastRead = System.currentTimeMillis();
 		} else if (System.currentTimeMillis() - lastRead > PDP.MAX_AGE) {
 			throw new InvalidSensorException("Can not read energy from PDP");
 		}
 	}
-	
+
 	/**
 	 * Gets the current voltage. This is the same for all channels.
 	 * This function defaults to the Driver Station voltage if the PDP becomes disconnected.
@@ -141,7 +142,7 @@ public class PDP {
 			return DriverStation.getInstance().getBatteryVoltage();
 		}
 	}
-	
+
 	/**
 	 * Gets the voltage on the battery.
 	 *
@@ -154,7 +155,7 @@ public class PDP {
 		readStatus(3);
 		return cachedVoltage;
 	}
-	
+
 	public double getBatteryResistance() {
 		try {
 			return getBatteryResistanceSafely();
@@ -164,12 +165,12 @@ public class PDP {
 			return cachedResistance;
 		}
 	}
-	
+
 	public double getBatteryResistanceSafely() throws InvalidSensorException {
 		readStatus(3);
 		return cachedResistance;
 	}
-	
+
 	public double getTotalCurrent() {
 		try {
 			return getTotalCurrentSafely();
@@ -179,7 +180,7 @@ public class PDP {
 			return cachedCurrent;
 		}
 	}
-	
+
 	/**
 	 * Gets the total current used by channels 0-15 of the PDP.
 	 *
@@ -192,7 +193,7 @@ public class PDP {
 		readEnergy();
 		return cachedCurrent;
 	}
-	
+
 	/**
 	 * Gets the total power used by channels 0-15 of the PDP.
 	 * 
@@ -208,7 +209,7 @@ public class PDP {
 			return cachedPower;
 		}
 	}
-	
+
 	/**
 	 * Gets the total power used by channels 0-15 of the PDP, throwing an exception when the PDP is disconnected.
 	 * 
@@ -221,7 +222,7 @@ public class PDP {
 		readEnergy();
 		return cachedPower;
 	}
-	
+
 	/**
 	 * Gets the total energy used by channels 0-15 of the PDP.
 	 * 
@@ -237,7 +238,7 @@ public class PDP {
 			return cachedEnergy;
 		}
 	}
-	
+
 	/**
 	 * Gets the total energy used by channels 0-15 of the PDP, throwing an exception when the PDP is disconnected.
 	 * 
@@ -250,7 +251,7 @@ public class PDP {
 		readEnergy();
 		return cachedEnergy;
 	}
-	
+
 	/**
 	 * Gets the current used by a single channel.
 	 *
@@ -276,7 +277,7 @@ public class PDP {
 		}
 		return cachedChannelCurrents[channel];
 	}
-	
+
 	/**
 	 * Gets the current used by a single channel.
 	 *

--- a/custom/sensors/PDP.java
+++ b/custom/sensors/PDP.java
@@ -78,9 +78,7 @@ public class PDP {
 				return;
 			}
 		}
-		catch (CANMessageUnavailableException e) {
-			return;
-		}
+		catch (CANMessageUnavailableException e) {}
 		if (rawArray != null) {
 			double[] tempCurrents = new double[numberCurrents];
 			tempCurrents[0] = ((rawArray[0] & 0xFF) << 2 | ((rawArray[1] & 0xC0) >> 6)) * 0.125;
@@ -106,13 +104,11 @@ public class PDP {
 	}
 
 	private void readEnergy() throws InvalidSensorException {
-		byte[] rawArray;
+		byte[] rawArray = null;
 		try {
 			rawArray = statusEnergy.read();
 		}
-		catch (CANMessageUnavailableException e) {
-			return;
-		}
+		catch (CANMessageUnavailableException e) {}
 		if (rawArray != null) {
 			cachedCurrent = (((rawArray[1] & 0xFF) << 4) | ((rawArray[2] & 0xF0) >> 4)) * 0.125;
 			cachedPower = (((rawArray[1] & 0x0F) << 12) | (rawArray[2] << 4) | ((rawArray[4] & 0xF0) >> 4)) * 0.125;


### PR DESCRIPTION
Should not have actually had an throw there, now just ignoring until timeout.