### PR TITLE
AccelerationCap no longer uses PDP DriverStation voltage fallback

### DIFF
--- a/subsystems/motor/speedmodifiers/AccelerationCap.java
+++ b/subsystems/motor/speedmodifiers/AccelerationCap.java
@@ -90,7 +90,7 @@ public class AccelerationCap implements SpeedModifier {
 			return 0;
 		}
 		// After doing updates, check for low battery voltage first
-		double currentVoltage = newVoltage; // Allow fallback to DS voltage
+		double currentVoltage = newVoltage;
 		if (currentVoltage < hardStopVoltage) { // If we are below hardStopVoltage, stop motors
 			LogKitten.w("Low voltage, AccelerationCap stopping motors");
 			return 0;


### PR DESCRIPTION
When the PDP was disconnected, it used to fallback to using voltage read from the DriverStation. This seems to have been suboptimal (still trying to figure out why). Now it simply falls back to a very basic version of ramping.