### PR TITLE
TypedNamedSendableChooser implements Supplier<T>

### DIFF
--- a/custom/TypedNamedSendableChooser.java
+++ b/custom/TypedNamedSendableChooser.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
  *
  * @param <T>
  */
-public class TypedNamedSendableChooser<T extends Nameable> extends SendableChooser<T> {
+public class TypedNamedSendableChooser<T extends Nameable> extends SendableChooser<T> implements Supplier<T>{
 	/**
 	 * Adds an object of the type
 	 * to the smart dashboard.
@@ -28,5 +28,11 @@ public class TypedNamedSendableChooser<T extends Nameable> extends SendableChoos
 	 */
 	public void addDefault(T object) {
 		super.addDefault(object.getName() + " (default)", object);
+	}
+	/**
+	 * Wrapper for getSelected() to conform to Supplier<T>
+	 */
+	public T get(){
+		return getSelected();
 	}
 }

--- a/custom/TypedNamedSendableChooser.java
+++ b/custom/TypedNamedSendableChooser.java
@@ -2,6 +2,7 @@ package org.usfirst.frc4904.standard.custom;
 
 
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import java.util.function.Supplier;
 
 /**
  * A sendable chooser for any named object.


### PR DESCRIPTION
If typednademsendablechooser implemented supplier, then you could have a pretty elegant way of, for example, having the driver station set a desired dead reckoning speed. Where your Supplier<Double>, passed into the PIDController, is just the TypedNamedSendableChooser<Double>