### PR TITLE
Update LogKitten.java

### DIFF
--- a/LogKitten.java
+++ b/LogKitten.java
@@ -149,7 +149,7 @@ public class LogKitten {
 		HAL.sendError(true, logLevel.getSeverity(), false, errorMessage, details, "", false);
 	}
 
-	public static synchronized void logMessage(Object message, KittenLevel level, boolean override) {
+	private static synchronized void logMessage(Object message, KittenLevel level, boolean override) {
 		message = message.toString(); // Not strictly needed, but good practice
 		if (LogKitten.logLevel.compareTo(level) >= 0) {
 			String content = LogKitten.timestamp() + " " + level.getName() + ": " + LogKitten.getLoggerMethodCallerMethodName()


### PR DESCRIPTION
Leaving `logMessage(Object message, KittenLevel level, boolean override)` as public introduces a subtle bug.

```private static String getLoggerMethodCallerMethodName() {
		return Thread.currentThread().getStackTrace()[4].getMethodName(); // caller of the logger method is fifth in the stack trace
	}```

This method gets the fifth item in the stack trace. Normally, a class calls, for example `void f(Object message) { // Log fatal message`, which then calls `LogKitten.logMessage(message, KittenLevel.FATAL, false);`. This results in the fifth item in the stack trace being, as expected, the function that calls LogKitten. 

However, if `logMessage` were public, the fifth item in the stack trace would be the function that calls the function that calls logkitten, resulting in incorrect logging.

The levels of indirection in calling LogKitten must be standardized, otherwise logging of what function called LogKitten will be inconsistent.