### PR TITLE
Added vanity TalonSRX wrapper

### DIFF
--- a/custom/motioncontrollers/CANTalonSRX.java
+++ b/custom/motioncontrollers/CANTalonSRX.java
@@ -1,0 +1,11 @@
+package org.usfirst.frc4904.standard.custom.motioncontrollers;
+
+
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+import edu.wpi.first.wpilibj.SpeedController;
+
+public class CANTalonSRX extends WPI_TalonSRX implements SpeedController {
+	public CANTalonSRX(int deviceNumber) {
+		super(deviceNumber);
+	}
+}


### PR DESCRIPTION
By using this we can ensure that in the likely event of a breaking update where they don't implement SpeedController, we can easily fix it without changing it in yearly code.

