### PR TITLE
Remove references to externally hosted files from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ install:
 - git clone https://github.com/RoboticsTeam4904/wpilib-mirror.git ~/wpilib
 - mkdir -p ~/wpilib/user/java/lib
 - git clone https://github.com/RoboticsTeam4904/4904-USERLIBS.git ~/wpilib/user/java/lib
-- curl -o ~/wpilib/java/current/ant/build.properties http://www.t4904.xyz/wiki/files/build.properties
 
 notifications:
   email: none

--- a/build.xml
+++ b/build.xml
@@ -13,9 +13,20 @@
 
   <target name="compile">
     <mkdir dir="build/classes"/>
-    <javac srcdir="${basedir}" destdir="build/classes" includeantruntime="false" >
-      <classpath path="${classpath}"/> <!-- classpath var is set in wpilib.properties -->
-    </javac>
+
+    <path id="classpath.path">
+      <fileset dir="${userLibs.dir}"
+               includes="*.jar"
+               excludes="*-sources.jar,*-javadoc.jar"
+               erroronmissingdir="true" />
+      <fileset file="${wpilib.jar}" />
+      <fileset file="${ntcore.jar}" />
+      <fileset file="${opencv.jar}" />
+      <fileset file="${cscore.jar}" />
+      <fileset file="${wpiutil.jar}" />
+    </path>
+
+    <javac srcdir="${basedir}" destdir="build/classes" includeantruntime="false" classpathref="classpath.path" />
   </target>
 
 </project>


### PR DESCRIPTION
No longer use t4904.xyz domain to host files required for building.