### PR TITLE
Wait for

### DIFF
--- a/commands/WaitFor.java
+++ b/commands/WaitFor.java
@@ -1,0 +1,40 @@
+package org.usfirst.frc4904.standard.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+
+public class WaitFor extends Command {
+	protected final double duration;
+
+	/**
+	 * A command that waits for a given amount of time, using setTimeout() to
+	 * continue with the command queue.
+	 *
+	 * @param duration
+	 *        A duration in seconds
+	 */
+	public WaitFor(double duration) {
+		super("WaitFor[" + duration + "]");
+		this.duration = duration;
+		setTimeout(duration);
+	}
+
+	@Override
+	protected void initialize() {}
+
+	@Override
+	protected void execute() {}
+
+	@Override
+	protected boolean isFinished() {
+		return isTimedOut();
+	}
+
+	@Override
+	protected void end() {}
+
+	@Override
+	protected void interrupted() {
+		end();
+	}
+}
+

--- a/commands/WaitFor.java
+++ b/commands/WaitFor.java
@@ -3,8 +3,6 @@ package org.usfirst.frc4904.standard.commands;
 import edu.wpi.first.wpilibj.command.Command;
 
 public class WaitFor extends Command {
-	protected final double duration;
-
 	/**
 	 * A command that waits for a given amount of time, using setTimeout() to
 	 * continue with the command queue.
@@ -14,7 +12,6 @@ public class WaitFor extends Command {
 	 */
 	public WaitFor(double duration) {
 		super("WaitFor[" + duration + "]");
-		this.duration = duration;
 		setTimeout(duration);
 	}
 


### PR DESCRIPTION
This branch adds a command `WaitFor()` in standard commands, which allows for an `addSequential()` call to wait for a specified amount of time.

```
class WaitFor extends Command {
    public WaitFor(double duration) { ... }
    public isFinished() { ... }
```

