### PR TITLE
Fix Util.isZero() zero detection using ULP heuristic

### DIFF
--- a/Util.java
+++ b/Util.java
@@ -16,8 +16,11 @@ public class Util {
 	 * @return
 	 * 		Whether or not it is within Double.MIN_VALUE of zero
 	 */
+	public static boolean isZero(double var, double epsilon) {
+		return Math.abs(var) < epsilon;
+	}
 	public static boolean isZero(double var) {
-		return Math.abs(var) < Double.MIN_VALUE;
+		return isZero(var, Math.sqrt(Math.ulp(1.0)));
 	}
 
 	public static class Range {


### PR DESCRIPTION
This is a direct response to #209 regarding Double.MIN_VALUE being used in Util.isZero().

**Summary**

A commonly used heuristic to determine whether or not a float is zero is to use the ULP of a double.  This is defined as the distance between the given double value and the double value next largest in magnitude. By taking the square root, we get a commonly used heuristic for determining whether or not a double is small enough to be considered zero. (Note that Java calculates this value to be approximately `1.4901161193847656E-8`.)

We restructure Util.isZero() to accept the following inputs:

- `Util.isZero(double var, double epsilon)` _Checks if `Math.abs(var) < epsilon`_
- `Util.isZero(double var)` _Calls the above method with `epsilon = Math.sqrt(Math.ulp(1.0))`_

This should not require changing any code besides the code modified in this pull request.